### PR TITLE
DEV-1680 Fix isFileTypeValid method to accept capitalized file types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@otr-app/ui-shared-services",
-  "version": "0.0.9",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@otr-app/ui-shared-services",
-      "version": "0.0.9",
+      "version": "0.1.4",
       "license": "ISC",
       "devDependencies": {
         "@types/angular": "~1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otr-app/ui-shared-services",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/services/file-handler.service.ts
+++ b/services/file-handler.service.ts
@@ -8,7 +8,7 @@ export class AppFileHandlerService {
   constructor(private $q) {}
 
   public isFileTypeValid(files) {
-    const extension = files[0].file.name.split(".").pop();
+    const extension = files[0].file.name.toLowerCase().split(".").pop();
     return !!{ png: 1, jpg: 1, jpeg: 1, pdf: 1 }[extension];
   }
 

--- a/tests/file-handler.service.spec.ts
+++ b/tests/file-handler.service.spec.ts
@@ -11,7 +11,7 @@ describe("file handler service", () => {
   }));
 
   it("should allow various images when isFileTypeValid is called", () => {
-    ["png", "jpg", "jpeg", "pdf"].forEach((type) => {
+    ["png", "jpg", "jpeg", "pdf", "PDF", "JPG", "PNG"].forEach((type) => {
       const files = [{ file: { name: "hello." + type } }];
       expect(service.isFileTypeValid(files)).toBeTrue();
     });


### PR DESCRIPTION
This PR will: 

- Add a fix to the `isFileTypeValid` method to accept capitalized file types (JPG, PNG, PDF);
- solution: add `.toLowerCase()` to the method to rule out differences by format
- modify tests to reflect new changes to isFileTypeValid